### PR TITLE
Expose props to child components

### DIFF
--- a/src/refnux.coffee
+++ b/src/refnux.coffee
@@ -135,7 +135,7 @@ connect = (viewfn) ->
     throw new Error("connect requires a function argument") unless typeof(viewfn) == 'function'
 
     # wrapped render function
-    ->
+    (props) ->
         unless provider
             throw new Error("No provider in scope. View function outside Provider?")
 
@@ -143,6 +143,6 @@ connect = (viewfn) ->
         dispatch = provider.store.dispatch
 
         # invoke the actual view function
-        viewfn(state, dispatch)
+        viewfn(state, dispatch, props)
 
 module.exports = {createStore, Provider, connect}

--- a/test/test-refnux.coffee
+++ b/test/test-refnux.coffee
@@ -163,7 +163,16 @@ describe 'connect', ->
         html = renderToString pel
         eql html, '<div data-reactroot="" data-reactid="1" '+
             'data-react-checksum="-1466167168">abc</div>'
-        eql vf.args, [[{panda:42}, store.dispatch]]
+        eql vf.args, [[{panda:42}, store.dispatch, undefined]]
+
+    it 'passes properties to wrapped component', ->
+        props = { some: 'prop' }
+        component = connect vf = spy -> div(null, 'abc')
+        app = -> component(props)
+        pel = pf({app, store})
+        eql vf.args, []
+        html = renderToString pel
+        eql vf.args, [[{panda:42}, store.dispatch, props]]
 
     it 'complains if connected function is used outside provider', ->
         app = connect -> div(null, 'abc')


### PR DESCRIPTION
I believe props are too important to be left behind. They do not
represent the state but they are often used to setup the
reusable components to better fit the context they are used in.

They are probably used for other sane things too, but the point is
that many react lib are using them so we can't just forget supporting
them.